### PR TITLE
Spelling

### DIFF
--- a/docs/database/index.md
+++ b/docs/database/index.md
@@ -1,7 +1,7 @@
 # Database
 
 The Database Module is a Wrapper with asnyc Support
-for[SQLAlchemy](https://www.sqlalchemy.org/)  .
+for [SQLAlchemy](https://www.sqlalchemy.org/)  .
 
 Its based on [PyDrocsid's Database Wrapper](https://github.com/PyDrocsid/library).
 


### PR DESCRIPTION
A missing space

**Description**
Better docs

**Additional Notes**
Add a missing space in the docs at the database index file.