### PR TITLE
Revert "Bump python from 3.14.2-alpine to 3.15.0a5-alpine"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.15.0a5-alpine
+FROM python:3.14.2-alpine
 
 RUN apk add --no-cache build-base musl-dev gcc yaml-dev
 


### PR DESCRIPTION
Reverts Tert0/fastapi-framework#372